### PR TITLE
preserve GameState from loaded game

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -99,8 +99,9 @@ def play_game(player, entities, game_map, message_log, game_state, con, panel, c
 
     key = libtcod.Key()
     mouse = libtcod.Mouse()
-
-    game_state = GameStates.PLAYERS_TURN
+    
+    if game_state == None:
+        game_state = GameStates.PLAYERS_TURN
     previous_game_state = game_state
 
     targeting_item = None


### PR DESCRIPTION
closes #33 

Simplest fix: don't override GameState if it exists on game start